### PR TITLE
add databaseEnvs to repo, implement waiting, and split out parser logic

### DIFF
--- a/cmd/kang/cmds.go
+++ b/cmd/kang/cmds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/zeet-co/kang/internal/config"
 
 	"github.com/zeet-co/kang/internal/controller"
@@ -131,6 +132,15 @@ func parseOverrides(stmts []string) map[uuid.UUID]map[string]string {
 	return output
 }
 
+func aliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	switch name {
+	case "overrides":
+		name = "override"
+		break
+	}
+	return pflag.NormalizedName(name)
+}
+
 func init() {
 	stopEnvironmentCmd.Flags().String("name", "", "Specify the name of the environment you'd like to stop")
 	stopEnvironmentCmd.MarkFlagRequired("name")
@@ -142,6 +152,7 @@ func init() {
 	startEnvironmentCmd.MarkFlagRequired("ids")
 
 	startEnvironmentCmd.Flags().StringSlice("overrides", []string{}, "Specify the Project ID : field : value combos that you would like to override. Format: project_id:field:value,proj.. Example: 1c6ea878-f92e-435e-a849-7bccfe7c6e5a:branch:feature-1")
+	startEnvironmentCmd.Flags().SetNormalizeFunc(aliasNormalizeFunc)
 
 	commentCmd.Flags().String("repo", "", "Github Repo that will be commented on")
 	commentCmd.MarkFlagRequired("repo")

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,81 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/zeet-co/kang/internal/parser"
+)
+
+func TestGetValue(t *testing.T) {
+	type Nested struct {
+		Detail string `json:"detail"`
+	}
+	type TestStruct struct {
+		Name    string            `json:"name"`
+		Numbers []int             `json:"numbers"`
+		Nested  Nested            `json:"nested"`
+		Info    map[string]string `json:"info"`
+	}
+
+	obj := TestStruct{
+		Name:    "Test",
+		Numbers: []int{1, 2, 3},
+		Nested:  Nested{Detail: "Detailed Info"},
+		Info:    map[string]string{"key1": "value1", "key2": "value2"},
+	}
+
+	tests := []struct {
+		name     string
+		jsonPath string
+		want     string
+	}{
+		{
+			name:     "Read simple field",
+			jsonPath: "name",
+			want:     "Test",
+		},
+		{
+			name:     "Read nested field",
+			jsonPath: "nested.detail",
+			want:     "Detailed Info",
+		},
+		{
+			name:     "Read array field",
+			jsonPath: "numbers[0]",
+			want:     "1",
+		},
+		{
+			name:     "Read array field",
+			jsonPath: "numbers[1]",
+			want:     "2",
+		},
+		{
+			name:     "Read map field",
+			jsonPath: "info.key1",
+			want:     "value1",
+		},
+		{
+			name:     "Read undefined field",
+			jsonPath: "undefined",
+			want:     "",
+		},
+		{
+			name:     "Read out-of-bounds array index",
+			jsonPath: "numbers[5]",
+			want:     "", // or the expected error message or behavior
+		},
+		{
+			name:     "Read non-existent map key",
+			jsonPath: "info.key3",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parser.GetValue(&obj, tt.jsonPath); got != tt.want {
+				t.Errorf("GetValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/zeet/v0/generated.go
+++ b/internal/zeet/v0/generated.go
@@ -151,6 +151,24 @@ const (
 	DeployTypeKubernetesUnstructured DeployType = "KUBERNETES_UNSTRUCTURED"
 )
 
+type DeploymentStatus string
+
+const (
+	DeploymentStatusBuildPending      DeploymentStatus = "BUILD_PENDING"
+	DeploymentStatusBuildInProgress   DeploymentStatus = "BUILD_IN_PROGRESS"
+	DeploymentStatusBuildFailed       DeploymentStatus = "BUILD_FAILED"
+	DeploymentStatusBuildSucceeded    DeploymentStatus = "BUILD_SUCCEEDED"
+	DeploymentStatusDeployPending     DeploymentStatus = "DEPLOY_PENDING"
+	DeploymentStatusDeployInProgress  DeploymentStatus = "DEPLOY_IN_PROGRESS"
+	DeploymentStatusReleaseInProgress DeploymentStatus = "RELEASE_IN_PROGRESS"
+	DeploymentStatusDeployFailed      DeploymentStatus = "DEPLOY_FAILED"
+	DeploymentStatusDeploySucceeded   DeploymentStatus = "DEPLOY_SUCCEEDED"
+	DeploymentStatusBuildAborted      DeploymentStatus = "BUILD_ABORTED"
+	DeploymentStatusDeployStopped     DeploymentStatus = "DEPLOY_STOPPED"
+	DeploymentStatusDeployHealhty     DeploymentStatus = "DEPLOY_HEALHTY"
+	DeploymentStatusDeployCrashing    DeploymentStatus = "DEPLOY_CRASHING"
+)
+
 type EnvVarInput struct {
 	Name   string `json:"name"`
 	Value  string `json:"value"`
@@ -1116,6 +1134,7 @@ type getRepoRepo struct {
 	Project              *getRepoRepoProject              `json:"project"`
 	ProjectEnvironment   *getRepoRepoProjectEnvironment   `json:"projectEnvironment"`
 	ProductionDeployment *getRepoRepoProductionDeployment `json:"productionDeployment"`
+	DatabaseEnvs         []getRepoRepoDatabaseEnvsEnvVar  `json:"databaseEnvs"`
 }
 
 // GetId returns getRepoRepo.Id, and is useful for accessing the field via an interface.
@@ -1140,6 +1159,21 @@ func (v *getRepoRepo) GetProductionDeployment() *getRepoRepoProductionDeployment
 	return v.ProductionDeployment
 }
 
+// GetDatabaseEnvs returns getRepoRepo.DatabaseEnvs, and is useful for accessing the field via an interface.
+func (v *getRepoRepo) GetDatabaseEnvs() []getRepoRepoDatabaseEnvsEnvVar { return v.DatabaseEnvs }
+
+// getRepoRepoDatabaseEnvsEnvVar includes the requested fields of the GraphQL type EnvVar.
+type getRepoRepoDatabaseEnvsEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// GetName returns getRepoRepoDatabaseEnvsEnvVar.Name, and is useful for accessing the field via an interface.
+func (v *getRepoRepoDatabaseEnvsEnvVar) GetName() string { return v.Name }
+
+// GetValue returns getRepoRepoDatabaseEnvsEnvVar.Value, and is useful for accessing the field via an interface.
+func (v *getRepoRepoDatabaseEnvsEnvVar) GetValue() string { return v.Value }
+
 // getRepoRepoOwnerUser includes the requested fields of the GraphQL type User.
 type getRepoRepoOwnerUser struct {
 	Login string `json:"login"`
@@ -1150,8 +1184,9 @@ func (v *getRepoRepoOwnerUser) GetLogin() string { return v.Login }
 
 // getRepoRepoProductionDeployment includes the requested fields of the GraphQL type Deployment.
 type getRepoRepoProductionDeployment struct {
-	Id        uuid.UUID `json:"id"`
-	Endpoints []string  `json:"endpoints"`
+	Id        uuid.UUID        `json:"id"`
+	Endpoints []string         `json:"endpoints"`
+	Status    DeploymentStatus `json:"status"`
 }
 
 // GetId returns getRepoRepoProductionDeployment.Id, and is useful for accessing the field via an interface.
@@ -1159,6 +1194,9 @@ func (v *getRepoRepoProductionDeployment) GetId() uuid.UUID { return v.Id }
 
 // GetEndpoints returns getRepoRepoProductionDeployment.Endpoints, and is useful for accessing the field via an interface.
 func (v *getRepoRepoProductionDeployment) GetEndpoints() []string { return v.Endpoints }
+
+// GetStatus returns getRepoRepoProductionDeployment.Status, and is useful for accessing the field via an interface.
+func (v *getRepoRepoProductionDeployment) GetStatus() DeploymentStatus { return v.Status }
 
 // getRepoRepoProject includes the requested fields of the GraphQL type Project.
 type getRepoRepoProject struct {
@@ -1417,6 +1455,11 @@ query getRepo ($id: UUID) {
 		productionDeployment {
 			id
 			endpoints
+			status
+		}
+		databaseEnvs {
+			name
+			value
 		}
 	}
 }


### PR DESCRIPTION
- add support for `--override` in addition to `--overrides`
- add support for `databaseEnvs` in overrides. This unlocks the ability to pass `databaseEnvs.[DATABASE_URL|DATABASE_HOSTNAME|DATABASE_PORT|DATABASE_USERNAME|DATABASE_PASSWORD|DATABASE_DATABASE]` between projects
- continuously poll if a symbolic environment variable references a project that is in a non-terminal state. In the case of an override referencing a field that will only be known after another project is deployed (i.e endpoint, above mentioned databaseEnvs), the `start` command will not exit until it is able to resolve that dependency 
- add support to parser module to support reading keys of maps off a struct. Previously, `"obj.foo.bar"` would resolve if `obj` had a struct under the field `foo` that itself had a field `bar`. Now this will also resolve if `foo` is a map that has a key `bar`
- added tests for the parser, as it has gotten more complicated