### PR TITLE
Ensure parent projects' environment variables aren't lost when env var overrides are passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.20 as builder
+FROM golang:1.22.3 as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/zeet-co/kang
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require (
 	github.com/Khan/genqlient v0.6.0
@@ -8,6 +10,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	github.com/vektah/gqlparser/v2 v2.5.1
 	golang.org/x/oauth2 v0.14.0
 	golang.org/x/sync v0.6.0
@@ -22,7 +25,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj0JTv4mTs=
+github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -30,6 +31,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v41 v41.0.0 h1:HseJrM2JFf2vfiZJ8anY2hqBjdfY1Vlj/K27ueww4gg=
 github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -40,6 +42,7 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -48,6 +51,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -59,6 +63,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUOHcr4=
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/zeet/v0/generated.go
+++ b/internal/zeet/v0/generated.go
@@ -1135,6 +1135,7 @@ type getRepoRepo struct {
 	ProjectEnvironment   *getRepoRepoProjectEnvironment   `json:"projectEnvironment"`
 	ProductionDeployment *getRepoRepoProductionDeployment `json:"productionDeployment"`
 	DatabaseEnvs         []getRepoRepoDatabaseEnvsEnvVar  `json:"databaseEnvs"`
+	Envs                 []getRepoRepoEnvsEnvVar          `json:"envs"`
 }
 
 // GetId returns getRepoRepo.Id, and is useful for accessing the field via an interface.
@@ -1162,6 +1163,9 @@ func (v *getRepoRepo) GetProductionDeployment() *getRepoRepoProductionDeployment
 // GetDatabaseEnvs returns getRepoRepo.DatabaseEnvs, and is useful for accessing the field via an interface.
 func (v *getRepoRepo) GetDatabaseEnvs() []getRepoRepoDatabaseEnvsEnvVar { return v.DatabaseEnvs }
 
+// GetEnvs returns getRepoRepo.Envs, and is useful for accessing the field via an interface.
+func (v *getRepoRepo) GetEnvs() []getRepoRepoEnvsEnvVar { return v.Envs }
+
 // getRepoRepoDatabaseEnvsEnvVar includes the requested fields of the GraphQL type EnvVar.
 type getRepoRepoDatabaseEnvsEnvVar struct {
 	Name  string `json:"name"`
@@ -1173,6 +1177,18 @@ func (v *getRepoRepoDatabaseEnvsEnvVar) GetName() string { return v.Name }
 
 // GetValue returns getRepoRepoDatabaseEnvsEnvVar.Value, and is useful for accessing the field via an interface.
 func (v *getRepoRepoDatabaseEnvsEnvVar) GetValue() string { return v.Value }
+
+// getRepoRepoEnvsEnvVar includes the requested fields of the GraphQL type EnvVar.
+type getRepoRepoEnvsEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// GetName returns getRepoRepoEnvsEnvVar.Name, and is useful for accessing the field via an interface.
+func (v *getRepoRepoEnvsEnvVar) GetName() string { return v.Name }
+
+// GetValue returns getRepoRepoEnvsEnvVar.Value, and is useful for accessing the field via an interface.
+func (v *getRepoRepoEnvsEnvVar) GetValue() string { return v.Value }
 
 // getRepoRepoOwnerUser includes the requested fields of the GraphQL type User.
 type getRepoRepoOwnerUser struct {
@@ -1458,6 +1474,10 @@ query getRepo ($id: UUID) {
 			status
 		}
 		databaseEnvs {
+			name
+			value
+		}
+		envs {
 			name
 			value
 		}

--- a/internal/zeet/v0/get_project.go
+++ b/internal/zeet/v0/get_project.go
@@ -21,6 +21,7 @@ type Repo struct {
 	SubGroupName         string            `json:"subGroupName"`
 	ProductionDeployment Deployment        `json:"deployment"`
 	DatabaseEnvs         map[string]string `json:"databaseEnvs"`
+	Envs                 map[string]string `json:"envs"`
 }
 
 func (c *Client) GetRepoByID(ctx context.Context, id uuid.UUID) (*Repo, error) {
@@ -49,6 +50,10 @@ query getRepo($id: UUID) {
 			name
 			value
 		}
+		envs {
+			name
+			value
+		}
   }
 }
 `
@@ -60,6 +65,11 @@ query getRepo($id: UUID) {
 	dbEnvs := make(map[string]string, len(res.Repo.DatabaseEnvs))
 	for _, e := range res.Repo.DatabaseEnvs {
 		dbEnvs[e.Name] = e.Value
+	}
+
+	envs := make(map[string]string, len(res.Repo.Envs))
+	for _, e := range res.Repo.Envs {
+		envs[e.Name] = e.Value
 	}
 
 	out = &Repo{
@@ -74,6 +84,7 @@ query getRepo($id: UUID) {
 			Status:    res.Repo.ProductionDeployment.Status,
 		},
 		DatabaseEnvs: dbEnvs,
+		Envs:         envs,
 	}
 
 	return out, err


### PR DESCRIPTION
When overrides are passed that include environment variables, kang duplicates the parent project, then uses the `setRepoEnvs` mutation to set the environment variables on the newly-created project to the values passed via override. 

When the parent project is duplicated, the Zeet backend automatically copies over all environment variables onto the newly created project.

This creates a case where any variables not defined in the overrides will not be present on the newly-created project, as `setRepoEnvs` issues a full replacement of the environment variables. This PR fixes this issue by fetching the environment variables of the parent project, and applying the overrides on top of them when issuing `setRepoEnvs`.