### PR TITLE
add re-build after applying overrides

### DIFF
--- a/internal/controller/comment.go
+++ b/internal/controller/comment.go
@@ -24,7 +24,7 @@ func (c *Controller) CommentGithub(ctx context.Context, prNumber int, repo, toke
 
 	sg := findSubGroup(group, envName)
 
-	projectIDs, err := c.getProjectsInSubGroup(ctx, c.groupName, sg)
+	projectIDs, err := c.getProjectsInSubGroup(c.groupName, sg)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func newGitHubAPIClient(ctx context.Context, token string, apiURL string, tlsCon
 func splitGitHubProject(project string) (string, string, error) {
 	parts := strings.SplitN(project, "/", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Invalid GitHub repository name: %s, expecting owner/repo", project)
+		return "", "", fmt.Errorf("invalid GitHub repository name: %s, expecting owner/repo", project)
 	}
 	return parts[0], parts[1], nil
 }

--- a/internal/controller/stop.go
+++ b/internal/controller/stop.go
@@ -42,17 +42,15 @@ func (c *Controller) StopEnvironment(ctx context.Context, envName string, teamID
 		return nil
 	}
 
-	ids, err := c.getProjectsInSubGroup(ctx, group.Name, sg)
+	ids, err := c.getProjectsInSubGroup(group.Name, sg)
 	if err != nil {
 		return err
 	}
 
-	if ids != nil {
-		for _, id := range ids {
-			fmt.Printf("Deleting project %s\n", id)
-			if err := c.zeet.DeleteProject(ctx, id); err != nil {
-				errs = append(errs, fmt.Errorf(fmt.Sprintf("failed to delete %s", err)))
-			}
+	for _, id := range ids {
+		fmt.Printf("Deleting project %s\n", id)
+		if err := c.zeet.DeleteProject(ctx, id); err != nil {
+			errs = append(errs, fmt.Errorf(fmt.Sprintf("failed to delete %s", err)))
 		}
 
 	}
@@ -66,7 +64,7 @@ func (c *Controller) StopEnvironment(ctx context.Context, envName string, teamID
 	return nil
 }
 
-func (c *Controller) getProjectsInSubGroup(ctx context.Context, groupName string, sg *v0.SubGroup) ([]uuid.UUID, error) {
+func (c *Controller) getProjectsInSubGroup(groupName string, sg *v0.SubGroup) ([]uuid.UUID, error) {
 
 	fmt.Printf("Found %d projects in %s/%s\n", len(sg.Projects), groupName, sg.Name)
 

--- a/internal/zeet/client.go
+++ b/internal/zeet/client.go
@@ -43,7 +43,7 @@ func (c *Client) GetGroup(ctx context.Context, group string) (*v0.GetSubGroupsFo
 
 func (c *Client) EnsureGroupsExist(ctx context.Context, teamName, group, subgroup string, teamID uuid.UUID) (uuid.UUID, uuid.UUID, error) {
 
-	groupID := uuid.Nil
+	var groupID uuid.UUID
 	subGroupID := uuid.Nil
 
 	resp, err := c.GetGroup(ctx, fmt.Sprintf("%s/%s", teamName, group))
@@ -159,4 +159,8 @@ func (c *Client) GetTeamName(ctx context.Context, teamID uuid.UUID) (*string, er
 
 func (c *Client) DeleteSubGroup(ctx context.Context, subGroupID uuid.UUID) error {
 	return c.v1Client.DeleteSubGroup(ctx, subGroupID)
+}
+
+func (c *Client) RebuildProject(ctx context.Context, projectID uuid.UUID) error {
+	return c.v0Client.RebuildProject(ctx, projectID)
 }

--- a/internal/zeet/v0/generated.go
+++ b/internal/zeet/v0/generated.go
@@ -896,6 +896,14 @@ func (v *UpdateProjectInput) GetPipelineClusterID() *uuid.UUID { return v.Pipeli
 // GetDeployTarget returns UpdateProjectInput.DeployTarget, and is useful for accessing the field via an interface.
 func (v *UpdateProjectInput) GetDeployTarget() *ProjectDeployInput { return v.DeployTarget }
 
+// __buildRepoInput is used internally by genqlient
+type __buildRepoInput struct {
+	Id uuid.UUID `json:"id"`
+}
+
+// GetId returns __buildRepoInput.Id, and is useful for accessing the field via an interface.
+func (v *__buildRepoInput) GetId() uuid.UUID { return v.Id }
+
 // __deleteRepoInput is used internally by genqlient
 type __deleteRepoInput struct {
 	Id uuid.UUID `json:"id"`
@@ -983,6 +991,23 @@ type __updateProjectInput struct {
 
 // GetInput returns __updateProjectInput.Input, and is useful for accessing the field via an interface.
 func (v *__updateProjectInput) GetInput() UpdateProjectInput { return v.Input }
+
+// buildRepoBuildRepo includes the requested fields of the GraphQL type Repo.
+type buildRepoBuildRepo struct {
+	// - v0.RepoID
+	Id uuid.UUID `json:"id"`
+}
+
+// GetId returns buildRepoBuildRepo.Id, and is useful for accessing the field via an interface.
+func (v *buildRepoBuildRepo) GetId() uuid.UUID { return v.Id }
+
+// buildRepoResponse is returned by buildRepo on success.
+type buildRepoResponse struct {
+	BuildRepo buildRepoBuildRepo `json:"buildRepo"`
+}
+
+// GetBuildRepo returns buildRepoResponse.BuildRepo, and is useful for accessing the field via an interface.
+func (v *buildRepoResponse) GetBuildRepo() buildRepoBuildRepo { return v.BuildRepo }
 
 // deleteRepoResponse is returned by deleteRepo on success.
 type deleteRepoResponse struct {
@@ -1293,6 +1318,41 @@ type updateProjectUpdateProjectRepo struct {
 
 // GetId returns updateProjectUpdateProjectRepo.Id, and is useful for accessing the field via an interface.
 func (v *updateProjectUpdateProjectRepo) GetId() uuid.UUID { return v.Id }
+
+// The query or mutation executed by buildRepo.
+const buildRepo_Operation = `
+mutation buildRepo ($id: ID!) {
+	buildRepo(id: $id, noCache: false) {
+		id
+	}
+}
+`
+
+func buildRepo(
+	ctx context.Context,
+	client graphql.Client,
+	id uuid.UUID,
+) (*buildRepoResponse, error) {
+	req := &graphql.Request{
+		OpName: "buildRepo",
+		Query:  buildRepo_Operation,
+		Variables: &__buildRepoInput{
+			Id: id,
+		},
+	}
+	var err error
+
+	var data buildRepoResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
 
 // The query or mutation executed by deleteRepo.
 const deleteRepo_Operation = `

--- a/internal/zeet/v0/rebuild.go
+++ b/internal/zeet/v0/rebuild.go
@@ -1,0 +1,25 @@
+package v0
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+)
+
+func (c *Client) RebuildProject(ctx context.Context, projectID uuid.UUID) error {
+	_ = `# @genqlient
+mutation buildRepo($id: ID!) {
+	buildRepo(id: $id, noCache: false) {
+		id
+	}
+}
+`
+
+	_, err := buildRepo(ctx, c.gql, projectID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Some projects require a rebuild or redeploy for overrides to take effect after applying them. With this change, kang will trigger a rebuild (using cache to speed up the process) after applying any overrides